### PR TITLE
Added Basic Camera Movement and Scenarios

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -247,15 +247,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2419416862562414633, guid: 1c7257354a8124530bc3b98945578539, type: 3}
       propertyPath: m_Name
-      value: Ground (2)
+      value: Ground_Test
       objectReference: {fileID: 0}
     - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
       propertyPath: m_LocalScale.x
-      value: 6.3
+      value: 8.78
       objectReference: {fileID: 0}
     - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.3
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
       propertyPath: m_LocalPosition.y
@@ -478,9 +478,9 @@ Transform:
   m_GameObject: {fileID: 519420028}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.2, y: 7.149, z: -14.727089}
+  m_LocalPosition: {x: 1.2016804, y: 7.05376, z: -14.727089}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -662,6 +662,7 @@ GameObject:
   - component: {fileID: 646207506}
   - component: {fileID: 646207505}
   - component: {fileID: 646207507}
+  - component: {fileID: 646207508}
   m_Layer: 0
   m_Name: PlayerCamera
   m_TagString: Untagged
@@ -719,7 +720,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.2, y: 7.149, z: -14.727089}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 236580278}
   m_Father: {fileID: 0}
@@ -739,8 +740,106 @@ MonoBehaviour:
   LeftPlayer: {fileID: 1785588492}
   RightPlayer: {fileID: 823809725}
   PlayerMidPoint: {fileID: 2000404803}
-  followTarget: {fileID: 0}
-  currentGOState: 2
+  followTarget: {fileID: 2000404806}
+  currentGOState: 0
+--- !u!114 &646207508
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 646207504}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2fba25a5cd15594e8f050a11e386c80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ConfineMode: 0
+  m_BoundingVolume: {fileID: 0}
+  m_BoundingShape2D: {fileID: 809841802}
+  m_ConfineScreenEdges: 1
+  m_Damping: 0
+--- !u!1 &809841800
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 809841801}
+  - component: {fileID: 809841802}
+  m_Layer: 0
+  m_Name: MapZero_CamConfiner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &809841801
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 809841800}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6.1, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1395771543}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!60 &809841802
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 809841800}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: -34.581886, y: 19.73128}
+      - {x: -34.143997, y: -6.061405}
+      - {x: 53.825363, y: -5.9687023}
+      - {x: 53.783016, y: 20.055876}
+  m_UseDelaunayMesh: 0
 --- !u!1 &823809725 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 262545657250061343, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
@@ -756,6 +855,38 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4696773489132715955, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
   m_PrefabInstance: {fileID: 552521862}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1395771542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1395771543}
+  m_Layer: 0
+  m_Name: CamConfiners
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1395771543
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1395771542}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.046684, y: 0.14574917, z: 12.765233}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 809841801}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1562698214
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -846,7 +977,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.4
+      value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
       propertyPath: m_LocalPosition.z
@@ -943,3 +1074,4 @@ SceneRoots:
   - {fileID: 141601884}
   - {fileID: 646207506}
   - {fileID: 2000404806}
+  - {fileID: 1395771543}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -151,6 +151,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player1
       objectReference: {fileID: 0}
+    - target: {fileID: 262545657250061343, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
+      propertyPath: m_TagString
+      value: LeftPlayer
+      objectReference: {fileID: 0}
     - target: {fileID: 2844957649778422485, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
       propertyPath: m_IsTrigger
       value: 0
@@ -233,6 +237,159 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
+--- !u!1001 &141601884
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2419416862562414633, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_Name
+      value: Ground (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 6.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+--- !u!1 &236580277
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 236580278}
+  - component: {fileID: 236580280}
+  - component: {fileID: 236580281}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &236580278
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236580277}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 646207506}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &236580280
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236580277}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &236580281
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236580277}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ad980451443d70438faac0bc6c235a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_TargetMovementOnly: 1
+  m_ScreenX: 0.5
+  m_ScreenY: 0.59
+  m_CameraDistance: 10
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0.81
+  m_DeadZoneDepth: 0
+  m_UnlimitedSoftZone: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 1.93
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+  m_GroupFramingMode: 2
+  m_AdjustmentMode: 0
+  m_GroupFramingSize: 0.8
+  m_MaxDollyIn: 5000
+  m_MaxDollyOut: 5000
+  m_MinimumDistance: 1
+  m_MaximumDistance: 5000
+  m_MinimumFOV: 3
+  m_MaximumFOV: 60
+  m_MinimumOrthoSize: 1
+  m_MaximumOrthoSize: 5000
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -245,6 +402,7 @@ GameObject:
   - component: {fileID: 519420031}
   - component: {fileID: 519420029}
   - component: {fileID: 519420033}
+  - component: {fileID: 519420034}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -291,11 +449,11 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
+  near clip plane: 7
+  far clip plane: 28.3
   field of view: 60
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 13.05
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -320,7 +478,7 @@ Transform:
   m_GameObject: {fileID: 519420028}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalPosition: {x: 1.2, y: 7.149, z: -14.727089}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -338,6 +496,40 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 69c1b22f588f74e4787b120261efcf0e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &519420034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowDebugText: 0
+  m_ShowCameraFrustum: 1
+  m_IgnoreTimeScale: 0
+  m_WorldUpOverride: {fileID: 0}
+  m_UpdateMethod: 2
+  m_BlendUpdateMethod: 1
+  m_DefaultBlend:
+    m_Style: 1
+    m_Time: 2
+    m_CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  m_CustomBlends: {fileID: 0}
+  m_CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &552521862
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -369,6 +561,10 @@ PrefabInstance:
     - target: {fileID: 262545657250061343, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
       propertyPath: m_Name
       value: Player2
+      objectReference: {fileID: 0}
+    - target: {fileID: 262545657250061343, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
+      propertyPath: m_TagString
+      value: RightPlayer
       objectReference: {fileID: 0}
     - target: {fileID: 2844957649778422485, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
       propertyPath: m_IsTrigger
@@ -455,6 +651,106 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
+--- !u!1 &646207504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 646207506}
+  - component: {fileID: 646207505}
+  - component: {fileID: 646207507}
+  m_Layer: 0
+  m_Name: PlayerCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &646207505
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 646207504}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 2000404806}
+  m_Follow: {fileID: 2000404806}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 13.05
+    NearClipPlane: 7
+    FarClipPlane: 28.3
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 236580278}
+--- !u!4 &646207506
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 646207504}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.2, y: 7.149, z: -14.727089}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 236580278}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &646207507
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 646207504}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4a8202e3bf2e421fb72221620a49cc9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  LeftPlayer: {fileID: 1785588492}
+  RightPlayer: {fileID: 823809725}
+  PlayerMidPoint: {fileID: 2000404803}
+  followTarget: {fileID: 0}
+  currentGOState: 2
+--- !u!1 &823809725 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 262545657250061343, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
+  m_PrefabInstance: {fileID: 552521862}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &823809730 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8843519180698908272, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
+  m_PrefabInstance: {fileID: 552521862}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1207245267 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4696773489132715955, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
@@ -522,6 +818,16 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4696773489132715955, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
   m_PrefabInstance: {fileID: 82400465}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1785588492 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 262545657250061343, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
+  m_PrefabInstance: {fileID: 82400465}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1785588497 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8843519180698908272, guid: 4751cdc81fd124d638596e25fb6d47d8, type: 3}
+  m_PrefabInstance: {fileID: 82400465}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1930362641
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -540,7 +846,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.17
+      value: -2.4
       objectReference: {fileID: 0}
     - target: {fileID: 7664369771253929918, guid: 1c7257354a8124530bc3b98945578539, type: 3}
       propertyPath: m_LocalPosition.z
@@ -579,6 +885,52 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1c7257354a8124530bc3b98945578539, type: 3}
+--- !u!1 &2000404803
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2000404806}
+  - component: {fileID: 2000404805}
+  m_Layer: 0
+  m_Name: PlayerMidPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2000404805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000404803}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c44933c610ef4871b9e1ba49bdc95c4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Player1: {fileID: 1785588497}
+  Player2: {fileID: 823809730}
+--- !u!4 &2000404806
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000404803}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.2, y: 4.8, z: -4.727089}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -588,3 +940,6 @@ SceneRoots:
   - {fileID: 552521862}
   - {fileID: 1930362641}
   - {fileID: 1562698214}
+  - {fileID: 141601884}
+  - {fileID: 646207506}
+  - {fileID: 2000404806}

--- a/Assets/Script/CameraManager.cs
+++ b/Assets/Script/CameraManager.cs
@@ -1,0 +1,71 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cinemachine;
+
+public class CameraManager : MonoBehaviour
+{
+    //Search for an active LeftPlayer and an active RightPlayer
+    public GameObject LeftPlayer;
+    public GameObject RightPlayer;
+    public GameObject PlayerMidPoint;
+
+    public Transform followTarget;
+
+    //to take whatever state is current in GameManager
+    public GOState currentGOState;
+
+    private CinemachineVirtualCamera playerVirtualCam;
+
+    //remember that Leftplayer always GORight, and Rightplayer always GOLeft!!!
+    public enum GOState
+    {
+        GORight,
+        GOLeft,
+        NoGO,
+    }
+
+    public void Start()
+    {
+        playerVirtualCam = GetComponent<CinemachineVirtualCamera>();
+    }
+
+    public void Update()
+    {
+        playerVirtualCam.Follow = followTarget;
+        playerVirtualCam.LookAt = followTarget;
+
+        switch (currentGOState)
+        {
+            case GOState.GORight:
+                if (LeftPlayer == null)
+                {
+                    LeftPlayer = GameObject.FindWithTag("LeftPlayer");
+                }
+                if (LeftPlayer != null)
+                {
+                    followTarget = PlayerMidPoint.transform;
+                }
+                    break;
+
+            case GOState.GOLeft:
+                if (RightPlayer == null)
+                {
+                    RightPlayer = GameObject.FindWithTag("RightPlayer");
+                }
+                if (RightPlayer != null)
+                {
+                    followTarget = PlayerMidPoint.transform;
+                }
+                break;
+
+            case GOState.NoGO:
+
+                followTarget = null;
+                
+                break;
+
+        }
+    }
+
+}

--- a/Assets/Script/CameraManager.cs
+++ b/Assets/Script/CameraManager.cs
@@ -10,12 +10,16 @@ public class CameraManager : MonoBehaviour
     public GameObject RightPlayer;
     public GameObject PlayerMidPoint;
 
+    //Update the followtarget for the virtual cam
     public Transform followTarget;
 
-    //to take whatever state is current in GameManager
+    //take whatever state that is current in the GameManager
     public GOState currentGOState;
 
+    //get virtual cam and cam width
     private CinemachineVirtualCamera playerVirtualCam;
+    private Camera cam;
+    private float camHalfWidth;
 
     //remember that Leftplayer always GORight, and Rightplayer always GOLeft!!!
     public enum GOState
@@ -28,6 +32,9 @@ public class CameraManager : MonoBehaviour
     public void Start()
     {
         playerVirtualCam = GetComponent<CinemachineVirtualCamera>();
+
+        cam = Camera.main;
+        camHalfWidth = cam.aspect * cam.orthographicSize;
     }
 
     public void Update()
@@ -45,6 +52,14 @@ public class CameraManager : MonoBehaviour
                 if (LeftPlayer != null)
                 {
                     followTarget = PlayerMidPoint.transform;
+                    var distance = LeftPlayer.transform.position.x - PlayerMidPoint.transform.position.x;
+                    //if distance indicates the leftplayer is heading left, it cannot move once reaching the point where rightplayer would be left out
+                    //if distance indicates the leftplayer is heading right, the camera shifts and a new right player would spawn on the right
+                    if (distance > camHalfWidth)
+                    {
+                        //out of camera border
+                        //actually this part has little camera behavior, it's just respawning the rightplayer on the right side of the leftplayer
+                    }
                 }
                     break;
 

--- a/Assets/Script/CameraManager.cs.meta
+++ b/Assets/Script/CameraManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4a8202e3bf2e421fb72221620a49cc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/PlayerMidPoint.cs
+++ b/Assets/Script/PlayerMidPoint.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerMidPoint : MonoBehaviour
+{
+    public Transform Player1;
+    public Transform Player2;
+
+    private void Update()
+    {
+        float midpointX = (Player1.position.x + Player2.position.x) / 2f;
+
+        // Set the position of this object to the calculated midpoint
+        this.transform.position = new Vector3(midpointX, this.transform.position.y, this.transform.position.z);
+    }
+
+}

--- a/Assets/Script/PlayerMidPoint.cs.meta
+++ b/Assets/Script/PlayerMidPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c44933c610ef4871b9e1ba49bdc95c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.unity.cinemachine": "2.9.7",
     "com.unity.collab-proxy": "2.3.1",
     "com.unity.feature.2d": "2.0.0",
     "com.unity.ide.rider": "3.0.28",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -104,6 +104,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.cinemachine": {
+      "version": "2.9.7",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.31"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.collab-proxy": {
       "version": "2.3.1",
       "depth": 0,

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,9 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - LeftPlayer
+  - RightPlayer
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Now camera can move according to different GOStates (which is how the GO arrow on the top indicate the round).
Still need implementation of multiple virtual cams shifting when a scene ends.  
Need limitation in player action when one moves to the edge of the camera, and need respawning actions when the player on their GO turn exits the edge of the camera.